### PR TITLE
feat: support `npm link my-package` and `yarn link my-package`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # yarn-link and npm-link node_modules/.bin/ fix
 
-`npm install my-package`/`yarn add my-package` usually links all my-package' dependencies' `bin` executables into the top-most `node_modules/.bin` (recursively). 
+`npm install my-package`/`yarn add my-package` usually links all my-package' dependencies' `bin` executables into the 
+top-most `node_modules/.bin` (recursively). 
 
-Currently, both `npm link my-package` / `yarn link my-package` and `npm install folder` don't do that. So if you have transitive dependencies (dependency of dependency) that has an executable, you will not be able to run it if linking with yarn/npm.
+Currently, both `npm link my-package` / `yarn link my-package` and `npm install folder` don't do that. So if you have 
+transitive dependencies (dependency of dependency) that has an executable, you will not be able to run it if linking 
+with yarn/npm.
 
-For example, you depend on `standard` which depend on `eslint`. When using `npm install`, you could just run `eslint src` and everything worked. With `npm link standard` this will not work.
+For example, you depend on `standard` which depend on `eslint`. When using `npm install`, you could just run 
+`eslint src` and everything worked. With `npm link standard` this will not work.
 
 ## Installation
 Install it globally (for ease of access, not necessary).
@@ -12,6 +16,8 @@ Install it globally (for ease of access, not necessary).
 `npm i -g yarn-bin-fix`
 
 ## Usage
-After linking your module using `npm link my-package` or `yarn link my-package`, run `yarn-bin-fix` from your **project's root**.
+After linking your module using `npm link my-package` or `yarn link my-package`, run `yarn-bin-fix` from your 
+**project's root**.
 
-Keep in mind that if you have `postinstall` scripts that use transitive dependencies, these will fail until you run this script.
+Keep in mind that if you have `postinstall` scripts that use transitive dependencies, these will fail until you run 
+this script.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `npm install my-package`/`yarn add my-package` usually links all my-package' dependencies' `bin` executables into the top-most `node_modules/.bin` (recursively). 
 
-Currently, both `npm link my-package` / `yarn link my-package` don't do that. So if you have transitive dependencies (dependency of dependency) that has an executable, you will not be able to run it if linking with yarn/npm.
+Currently, both `npm link my-package` / `yarn link my-package` and `npm install folder` don't do that. So if you have transitive dependencies (dependency of dependency) that has an executable, you will not be able to run it if linking with yarn/npm.
 
 For example, you depend on `standard` which depend on `eslint`. When using `npm install`, you could just run `eslint src` and everything worked. With `npm link standard` this will not work.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-# yarn node_modules/.bin/ fix
-Fix for yarn's [#760](https://github.com/yarnpkg/yarn/issues/760)
+# yarn-link and npm-link node_modules/.bin/ fix
 
-This does exactly what npm usually does, links all package.json's `bin` executables into the top-most `node_modules/.bin` (recursively). 
+`npm install my-package`/`yarn add my-package` usually links all my-package' dependencies' `bin` executables into the top-most `node_modules/.bin` (recursively). 
 
-Currently, yarn does not do that. So if you have transitive dependencies (dependency of dependency) that has an executable, you will not be able to run it if installing with yarn.
+Currently, both `npm link my-package` / `yarn link my-package` don't do that. So if you have transitive dependencies (dependency of dependency) that has an executable, you will not be able to run it if linking with yarn/npm.
 
-For example, you depend on `standard` which depend on `eslint`. When using npm, you could just run `eslint src` and everything worked. With yarn this will not work.
-
-This is not a perfect solution, but this script will allow you to migrate to yarn more easily. See (#1210)(https://github.com/yarnpkg/yarn/pull/1210).
+For example, you depend on `standard` which depend on `eslint`. When using `npm install`, you could just run `eslint src` and everything worked. With `npm link standard` this will not work.
 
 ## Installation
 Install it globally (for ease of access, not necessary).
@@ -15,6 +12,6 @@ Install it globally (for ease of access, not necessary).
 `npm i -g yarn-bin-fix`
 
 ## Usage
-After installing your module using `yarn`, run `yarn-bin-fix` from your **project's root**.
+After linking your module using `npm link my-package` or `yarn link my-package`, run `yarn-bin-fix` from your **project's root**.
 
 Keep in mind that if you have `postinstall` scripts that use transitive dependencies, these will fail until you run this script.

--- a/bin/yarn-bin-fix
+++ b/bin/yarn-bin-fix
@@ -23,7 +23,7 @@ function createBinFolder() {
 }
 
 function findAllPackageJsonsFiles() {
-  const found = execRead(`find ${nodeModules} -type f -name 'package.json'`);
+  const found = execRead(`find -L ${nodeModules} -type f -name 'package.json'`);
   return _.split(found, '\n');
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn-bin-fix",
   "version": "0.1.15",
-  "description": "Fix for yarn's #760, puts all executables from node_modules into .bin, as npm usually does",
+  "description": "Workaround for npm-link re binaries of packages' subdependencies",
   "license": "MIT",
   "author": "Daniel Zlotin <zlotindaniel@gmail.com>",
   "publishConfig": {


### PR DESCRIPTION
`yarn install` doesn't suffer anymore (as of v1.5.1 at least) from the issue this package solves, but npm-link, yarn-link and `npm install folder` do: they only link binaries specified in linked module's package.json, not in its dependencies.

Let's cover this case now by telling `find` to traverse linked directories, too.